### PR TITLE
fix: pin poorman-handshake>=2.0.0a1 + disable-able runtime password backstop

### DIFF
--- a/hivemind_http_protocol/__init__.py
+++ b/hivemind_http_protocol/__init__.py
@@ -20,6 +20,7 @@ from tornado import web
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
 from hivemind_bus_client.message import HiveMessageType
+from hivemind_core.config import runtime_password_min_bits
 from hivemind_core.protocol import (
     HiveMindListenerProtocol,
     HiveMindClientConnection,
@@ -185,7 +186,7 @@ class HiveMindHttpHandler(web.RequestHandler):
         client.is_admin = user.is_admin
         if user.password:
             # pre-shared password to derive aes_key
-            client.pswd_handshake = PasswordHandShake(user.password)
+            client.pswd_handshake = PasswordHandShake(user.password, min_bits=runtime_password_min_bits())
 
         client.node_type = HiveMindNodeType.NODE  # TODO . placeholder
         if cache:

--- a/hivemind_http_protocol/__init__.py
+++ b/hivemind_http_protocol/__init__.py
@@ -20,7 +20,14 @@ from tornado import web
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
 from hivemind_bus_client.message import HiveMessageType
-from hivemind_core.config import runtime_password_min_bits
+try:
+    from hivemind_core.config import runtime_password_min_bits
+except ImportError:  # released hivemind-core without the helper
+    import os
+
+    def runtime_password_min_bits():
+        return 0.0 if os.environ.get("HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK", "").strip().lower() in ("1", "true", "yes", "on") else 40.0
+
 from hivemind_core.protocol import (
     HiveMindListenerProtocol,
     HiveMindClientConnection,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ requires-python = ">=3.10"
 dependencies = [
     "tornado",
     "hivemind-plugin-manager",
-    "poorman_handshake>=0.1.0",
+    "poorman-handshake>=2.0.0a1,<3.0.0",
+    "hivemind-core",
     "pyOpenSSL",
     "pybase64",
     "hivemind-bus-client",

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -96,7 +96,7 @@ def _make_handler(cls, auth_value, proto, *, extra_get_arg=None):
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +169,8 @@ class TestGetClient:
         _clean_class_state()
         HiveMindHttpHandler.hm_protocol = proto
 
-        user = _make_user(password="hunter2")
+        # password must satisfy the runtime strength backstop (poorman-handshake 2.x)
+        user = _make_user(password="correct-horse-battery-staple-9$")
         with patch.object(proto.db, "get_client_by_api_key", return_value=user):
             h = HiveMindHttpHandler.__new__(HiveMindHttpHandler)
             result = h.get_client("agent", "pwdkey", cache=False)
@@ -421,7 +422,7 @@ class TestSendMessageHandler:
 
     def test_send_exception_returns_500(self, master):
         proto = master.hm_protocol
-        with patch.object(proto.db, "sync", side_effect=RuntimeError("boom")):
+        with patch.object(proto, "handle_message", side_effect=RuntimeError("boom")):
             h = _make_handler(SendMessageHandler, _encode("agent:errkey"), proto,
                               extra_get_arg={"message": "msg"})
             SendMessageHandler.clients["errkey"] = MagicMock()


### PR DESCRIPTION
## Summary

- Pins `poorman-handshake>=2.0.0a1,<3.0.0` (2.x encryption/handshake API).
- Wires the poorman 2.0 password-strength check as a **runtime security backstop**: `PasswordHandShake(user.password, min_bits=runtime_password_min_bits())`. This catches weak passwords inserted by editing the database directly, at handshake time.
- The backstop is disable-able: set env `HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK=1` or config `runtime_password_strength_check: false` (helper `runtime_password_min_bits()` in `hivemind_core.config` returns 0 when disabled, else configured `min_password_bits`, default 40).
- Adds `hivemind-core` to runtime deps (module already imported `hivemind_core.protocol`; the dep was implicit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)